### PR TITLE
fixes #5 by linking properly to the renamed file

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ At July 2018 there are:
 
 ## The lookup as certification
 
-Some examples and fields description for the [`lookup.csv`](data/lookup.csv) main dataset of this project.
+Some examples and fields description for the [`lookup.csv`](data/int-lookup.csv) main dataset of this project.
 
 wdId|osm_type|osm_id|isReciprocal|check_date
 ----|--------|------|------|-------

--- a/data/README.md
+++ b/data/README.md
@@ -1,6 +1,6 @@
 ## Main files
 
-The main file, to use in resolvers or to control the OSM-Wikidata reciprocal citation, is [`lookup.csv`](lookup.csv).
+The main file, to use in resolvers or to control the OSM-Wikidata reciprocal citation, is [`lookup.csv`](int-lookup.csv).
 
 During the checking-process the file [`lookup_errors_WIKIDATA.csv`](lookup_errors_WIKIDATA.csv) is generated, and can be used by human team or automated tasks, o fix bugs.
 


### PR DESCRIPTION
The links now point to the new name `int-lookup.csv`.